### PR TITLE
Refactor: Extract Auth Logic from AuthModal into Hooks and Presentational Components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bridge-to-scale",
+  "name": "aws-camp-minority-businesses",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bridge-to-scale",
+      "name": "aws-camp-minority-businesses",
       "version": "0.0.0",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.15.0",
@@ -169,6 +169,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.1.tgz",
       "integrity": "sha512-WHO6yYegmnZ+K3vnYzVwy+wnxYqSkdFakBIlgm4922QXHOQYWdIl/rrTcaagrpJEGT6YlTnqx1ANIoPojNxWmw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.973.1",
@@ -5973,6 +5974,7 @@
       "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.16.2.tgz",
       "integrity": "sha512-7CHwfH5QxZ0rzCws/DNy5VLVcIIZWd9iUTtV1Oj6kPzpkFhCJ2I8gTvhFdh61HLhrg2lShcPQ8cecBIQS/ZJ0A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-amplify/analytics": "7.0.93",
         "@aws-amplify/api": "6.3.24",
@@ -7304,6 +7306,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8653,6 +8656,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9038,6 +9042,7 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.3.tgz",
       "integrity": "sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,12 +1,11 @@
-import { useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { toast } from 'sonner';
-import { resetPassword, confirmResetPassword } from 'aws-amplify/auth';
+import { useAuthFlows } from '@/hooks/useAuthFlows';
+import { usePasswordReset } from '@/hooks/usePasswordReset';
+import { SignInForm } from '@/components/auth/SignInForm';
+import { SignUpForm } from '@/components/auth/SignUpForm';
+import { ConfirmEmailForm } from '@/components/auth/ConfirmEmailForm';
+import { ForgotPasswordForm } from '@/components/auth/ForgotPasswordForm';
 
 interface AuthModalProps {
   open: boolean;
@@ -14,113 +13,27 @@ interface AuthModalProps {
 }
 
 export const AuthModal = ({ open, onOpenChange }: AuthModalProps) => {
-  const { signIn, signUp, confirmSignUp } = useAuth();
-  const [loading, setLoading] = useState(false);
-  const [showConfirmation, setShowConfirmation] = useState(false);
-  const [showForgotPassword, setShowForgotPassword] = useState(false);
-  const [pendingUsername, setPendingUsername] = useState('');
+  const authFlows = useAuthFlows({
+    onClose: () => onOpenChange(false),
+  });
 
-  // Sign In Form
-  const [signInData, setSignInData] = useState({ username: '', password: '' });
+  const passwordReset = usePasswordReset({
+    onComplete: () => {
+      authFlows.goToSignIn();
+    },
+  });
 
-  // Sign Up Form
-  const [signUpData, setSignUpData] = useState({ username: '', email: '', password: '', confirmPassword: '' });
-
-  // Confirmation Form
-  const [confirmationCode, setConfirmationCode] = useState('');
-
-  // Forgot Password Form
-  const [forgotPasswordData, setForgotPasswordData] = useState({ username: '', code: '', newPassword: '' });
-  const [forgotPasswordStep, setForgotPasswordStep] = useState<'request' | 'reset'>('request');
-
-  const handleSignIn = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      await signIn(signInData.username, signInData.password);
-      toast.success('Successfully signed in!');
-      onOpenChange(false);
-      setSignInData({ username: '', password: '' });
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to sign in');
-    } finally {
-      setLoading(false);
-    }
+  const handleForgotPassword = () => {
+    passwordReset.resetState();
+    authFlows.goToForgotPassword();
   };
 
-  const handleSignUp = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    if (signUpData.password !== signUpData.confirmPassword) {
-      toast.error('Passwords do not match');
-      return;
-    }
-
-    setLoading(true);
-    try {
-      await signUp(signUpData.username, signUpData.email, signUpData.password);
-      setPendingUsername(signUpData.username);
-      setShowConfirmation(true);
-      toast.success('Account created! Please check your email for confirmation code.');
-      setSignUpData({ username: '', email: '', password: '', confirmPassword: '' });
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to sign up');
-    } finally {
-      setLoading(false);
-    }
+  const handleBackToSignInFromForgotPassword = () => {
+    passwordReset.resetState();
+    authFlows.goToSignIn();
   };
 
-  const handleConfirmSignUp = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      await confirmSignUp(pendingUsername, confirmationCode);
-      toast.success('Email confirmed! You can now sign in.');
-      setShowConfirmation(false);
-      setConfirmationCode('');
-      setPendingUsername('');
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to confirm email');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleForgotPasswordRequest = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      await resetPassword({ username: forgotPasswordData.username });
-      toast.success('Reset code sent to your email');
-      setForgotPasswordStep('reset');
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to send reset code');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handlePasswordReset = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    try {
-      await confirmResetPassword({
-        username: forgotPasswordData.username,
-        confirmationCode: forgotPasswordData.code,
-        newPassword: forgotPasswordData.newPassword,
-      });
-      toast.success('Password reset successful! You can now sign in.');
-      setShowForgotPassword(false);
-      setForgotPasswordData({ username: '', code: '', newPassword: '' });
-      setForgotPasswordStep('request');
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to reset password');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  if (showConfirmation) {
+  if (authFlows.mode === 'confirm') {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent>
@@ -130,113 +43,44 @@ export const AuthModal = ({ open, onOpenChange }: AuthModalProps) => {
               Enter the confirmation code sent to your email
             </DialogDescription>
           </DialogHeader>
-          <form onSubmit={handleConfirmSignUp} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="code">Confirmation Code</Label>
-              <Input
-                id="code"
-                type="text"
-                value={confirmationCode}
-                onChange={(e) => setConfirmationCode(e.target.value)}
-                placeholder="Enter 6-digit code"
-                required
-              />
-            </div>
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? 'Confirming...' : 'Confirm Email'}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              className="w-full"
-              onClick={() => setShowConfirmation(false)}
-            >
-              Back to Sign Up
-            </Button>
-          </form>
+          <ConfirmEmailForm
+            value={authFlows.confirmationCode}
+            loading={authFlows.loading}
+            onChange={authFlows.setConfirmationCode}
+            onSubmit={authFlows.handleConfirmSignUp}
+            onBack={authFlows.goToSignUp}
+          />
         </DialogContent>
       </Dialog>
     );
   }
 
-  if (showForgotPassword) {
+  if (authFlows.mode === 'forgot') {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Reset Password</DialogTitle>
             <DialogDescription>
-              {forgotPasswordStep === 'request' 
+              {passwordReset.forgotPasswordStep === 'request'
                 ? 'Enter your username to receive a reset code'
                 : 'Enter the code from your email and your new password'}
             </DialogDescription>
           </DialogHeader>
-          
-          {forgotPasswordStep === 'request' ? (
-            <form onSubmit={handleForgotPasswordRequest} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="forgot-username">Username</Label>
-                <Input
-                  id="forgot-username"
-                  type="text"
-                  value={forgotPasswordData.username}
-                  onChange={(e) => setForgotPasswordData({ ...forgotPasswordData, username: e.target.value })}
-                  placeholder="Enter your username"
-                  required
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Sending...' : 'Send Reset Code'}
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                className="w-full"
-                onClick={() => setShowForgotPassword(false)}
-              >
-                Back to Sign In
-              </Button>
-            </form>
-          ) : (
-            <form onSubmit={handlePasswordReset} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="reset-code">Reset Code</Label>
-                <Input
-                  id="reset-code"
-                  type="text"
-                  value={forgotPasswordData.code}
-                  onChange={(e) => setForgotPasswordData({ ...forgotPasswordData, code: e.target.value })}
-                  placeholder="Enter code from email"
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="new-password">New Password</Label>
-                <Input
-                  id="new-password"
-                  type="password"
-                  value={forgotPasswordData.newPassword}
-                  onChange={(e) => setForgotPasswordData({ ...forgotPasswordData, newPassword: e.target.value })}
-                  placeholder="Enter new password"
-                  required
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Resetting...' : 'Reset Password'}
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                className="w-full"
-                onClick={() => {
-                  setForgotPasswordStep('request');
-                  setShowForgotPassword(false);
-                }}
-              >
-                Back to Sign In
-              </Button>
-            </form>
-          )}
+          <ForgotPasswordForm
+            step={passwordReset.forgotPasswordStep}
+            values={passwordReset.forgotPasswordData}
+            loading={passwordReset.loading}
+            onChange={(field, value) =>
+              passwordReset.setForgotPasswordData({
+                ...passwordReset.forgotPasswordData,
+                [field]: value,
+              })
+            }
+            onRequestSubmit={passwordReset.handleForgotPasswordRequest}
+            onResetSubmit={passwordReset.handlePasswordReset}
+            onBackToSignIn={handleBackToSignInFromForgotPassword}
+          />
         </DialogContent>
       </Dialog>
     );
@@ -251,100 +95,47 @@ export const AuthModal = ({ open, onOpenChange }: AuthModalProps) => {
             Sign in to your account or create a new one
           </DialogDescription>
         </DialogHeader>
-        <Tabs defaultValue="signin" className="w-full">
+        <Tabs
+          value={authFlows.mode === 'signup' ? 'signup' : 'signin'}
+          onValueChange={(value) => {
+            if (value === 'signup') {
+              authFlows.goToSignUp();
+            } else {
+              authFlows.goToSignIn();
+            }
+          }}
+          className="w-full"
+        >
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="signin">Sign In</TabsTrigger>
             <TabsTrigger value="signup">Sign Up</TabsTrigger>
           </TabsList>
-          
           <TabsContent value="signin">
-            <form onSubmit={handleSignIn} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="signin-username">Username</Label>
-                <Input
-                  id="signin-username"
-                  type="text"
-                  value={signInData.username}
-                  onChange={(e) => setSignInData({ ...signInData, username: e.target.value })}
-                  placeholder="Enter your username"
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="signin-password">Password</Label>
-                <Input
-                  id="signin-password"
-                  type="password"
-                  value={signInData.password}
-                  onChange={(e) => setSignInData({ ...signInData, password: e.target.value })}
-                  placeholder="Enter your password"
-                  required
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Signing in...' : 'Sign In'}
-              </Button>
-              <Button
-                type="button"
-                variant="link"
-                className="w-full text-sm"
-                onClick={() => setShowForgotPassword(true)}
-              >
-                Forgot password?
-              </Button>
-            </form>
+            <SignInForm
+              values={authFlows.signInData}
+              loading={authFlows.loading}
+              onChange={(field, value) =>
+                authFlows.setSignInData({
+                  ...authFlows.signInData,
+                  [field]: value,
+                })
+              }
+              onSubmit={authFlows.handleSignIn}
+              onForgotPassword={handleForgotPassword}
+            />
           </TabsContent>
-          
           <TabsContent value="signup">
-            <form onSubmit={handleSignUp} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="signup-username">Username</Label>
-                <Input
-                  id="signup-username"
-                  type="text"
-                  value={signUpData.username}
-                  onChange={(e) => setSignUpData({ ...signUpData, username: e.target.value })}
-                  placeholder="Choose a username"
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="signup-email">Email</Label>
-                <Input
-                  id="signup-email"
-                  type="email"
-                  value={signUpData.email}
-                  onChange={(e) => setSignUpData({ ...signUpData, email: e.target.value })}
-                  placeholder="your@email.com"
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="signup-password">Password</Label>
-                <Input
-                  id="signup-password"
-                  type="password"
-                  value={signUpData.password}
-                  onChange={(e) => setSignUpData({ ...signUpData, password: e.target.value })}
-                  placeholder="Create a password"
-                  required
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="signup-confirm-password">Confirm Password</Label>
-                <Input
-                  id="signup-confirm-password"
-                  type="password"
-                  value={signUpData.confirmPassword}
-                  onChange={(e) => setSignUpData({ ...signUpData, confirmPassword: e.target.value })}
-                  placeholder="Confirm your password"
-                  required
-                />
-              </div>
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Creating account...' : 'Sign Up'}
-              </Button>
-            </form>
+            <SignUpForm
+              values={authFlows.signUpData}
+              loading={authFlows.loading}
+              onChange={(field, value) =>
+                authFlows.setSignUpData({
+                  ...authFlows.signUpData,
+                  [field]: value,
+                })
+              }
+              onSubmit={authFlows.handleSignUp}
+            />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/src/components/auth/ConfirmEmailForm.tsx
+++ b/src/components/auth/ConfirmEmailForm.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface ConfirmEmailFormProps {
+  value: string;
+  loading: boolean;
+  onChange: (value: string) => void;
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  onBack: () => void;
+}
+
+export const ConfirmEmailForm = ({
+  value,
+  loading,
+  onChange,
+  onSubmit,
+  onBack,
+}: ConfirmEmailFormProps) => {
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="code">Confirmation Code</Label>
+        <Input
+          id="code"
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Enter 6-digit code"
+          required
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? 'Confirming...' : 'Confirm Email'}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        className="w-full"
+        onClick={onBack}
+      >
+        Back to Sign Up
+      </Button>
+    </form>
+  );
+};
+

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,99 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type ForgotPasswordStep = 'request' | 'reset';
+
+interface ForgotPasswordFormValues {
+  username: string;
+  code: string;
+  newPassword: string;
+}
+
+interface ForgotPasswordFormProps {
+  step: ForgotPasswordStep;
+  values: ForgotPasswordFormValues;
+  loading: boolean;
+  onChange: (field: keyof ForgotPasswordFormValues, value: string) => void;
+  onRequestSubmit: React.FormEventHandler<HTMLFormElement>;
+  onResetSubmit: React.FormEventHandler<HTMLFormElement>;
+  onBackToSignIn: () => void;
+}
+
+export const ForgotPasswordForm = ({
+  step,
+  values,
+  loading,
+  onChange,
+  onRequestSubmit,
+  onResetSubmit,
+  onBackToSignIn,
+}: ForgotPasswordFormProps) => {
+  if (step === 'request') {
+    return (
+      <form onSubmit={onRequestSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="forgot-username">Username</Label>
+          <Input
+            id="forgot-username"
+            type="text"
+            value={values.username}
+            onChange={(e) => onChange('username', e.target.value)}
+            placeholder="Enter your username"
+            required
+          />
+        </div>
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? 'Sending...' : 'Send Reset Code'}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full"
+          onClick={onBackToSignIn}
+        >
+          Back to Sign In
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <form onSubmit={onResetSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="reset-code">Reset Code</Label>
+        <Input
+          id="reset-code"
+          type="text"
+          value={values.code}
+          onChange={(e) => onChange('code', e.target.value)}
+          placeholder="Enter code from email"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="new-password">New Password</Label>
+        <Input
+          id="new-password"
+          type="password"
+          value={values.newPassword}
+          onChange={(e) => onChange('newPassword', e.target.value)}
+          placeholder="Enter new password"
+          required
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? 'Resetting...' : 'Reset Password'}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        className="w-full"
+        onClick={onBackToSignIn}
+      >
+        Back to Sign In
+      </Button>
+    </form>
+  );
+};
+

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -1,0 +1,63 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface SignInFormValues {
+  username: string;
+  password: string;
+}
+
+interface SignInFormProps {
+  values: SignInFormValues;
+  loading: boolean;
+  onChange: (field: keyof SignInFormValues, value: string) => void;
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  onForgotPassword: () => void;
+}
+
+export const SignInForm = ({
+  values,
+  loading,
+  onChange,
+  onSubmit,
+  onForgotPassword,
+}: SignInFormProps) => {
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="signin-username">Username</Label>
+        <Input
+          id="signin-username"
+          type="text"
+          value={values.username}
+          onChange={(e) => onChange('username', e.target.value)}
+          placeholder="Enter your username"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="signin-password">Password</Label>
+        <Input
+          id="signin-password"
+          type="password"
+          value={values.password}
+          onChange={(e) => onChange('password', e.target.value)}
+          placeholder="Enter your password"
+          required
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? 'Signing in...' : 'Sign In'}
+      </Button>
+      <Button
+        type="button"
+        variant="link"
+        className="w-full text-sm"
+        onClick={onForgotPassword}
+      >
+        Forgot password?
+      </Button>
+    </form>
+  );
+};
+

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,0 +1,77 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface SignUpFormValues {
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+interface SignUpFormProps {
+  values: SignUpFormValues;
+  loading: boolean;
+  onChange: (field: keyof SignUpFormValues, value: string) => void;
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+}
+
+export const SignUpForm = ({
+  values,
+  loading,
+  onChange,
+  onSubmit,
+}: SignUpFormProps) => {
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="signup-username">Username</Label>
+        <Input
+          id="signup-username"
+          type="text"
+          value={values.username}
+          onChange={(e) => onChange('username', e.target.value)}
+          placeholder="Choose a username"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="signup-email">Email</Label>
+        <Input
+          id="signup-email"
+          type="email"
+          value={values.email}
+          onChange={(e) => onChange('email', e.target.value)}
+          placeholder="your@email.com"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="signup-password">Password</Label>
+        <Input
+          id="signup-password"
+          type="password"
+          value={values.password}
+          onChange={(e) => onChange('password', e.target.value)}
+          placeholder="Create a password"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="signup-confirm-password">Confirm Password</Label>
+        <Input
+          id="signup-confirm-password"
+          type="password"
+          value={values.confirmPassword}
+          onChange={(e) => onChange('confirmPassword', e.target.value)}
+          placeholder="Confirm your password"
+          required
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? 'Creating account...' : 'Sign Up'}
+      </Button>
+    </form>
+  );
+};
+

--- a/src/hooks/useAuthFlows.ts
+++ b/src/hooks/useAuthFlows.ts
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+
+type AuthMode = 'signin' | 'signup' | 'confirm' | 'forgot';
+
+interface UseAuthFlowsOptions {
+  onClose: () => void;
+}
+
+interface SignInData {
+  username: string;
+  password: string;
+}
+
+interface SignUpData {
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export const useAuthFlows = ({ onClose }: UseAuthFlowsOptions) => {
+  const { signIn, signUp, confirmSignUp } = useAuth();
+
+  const [mode, setMode] = useState<AuthMode>('signin');
+  const [loading, setLoading] = useState(false);
+  const [pendingUsername, setPendingUsername] = useState('');
+
+  const [signInData, setSignInData] = useState<SignInData>({
+    username: '',
+    password: '',
+  });
+
+  const [signUpData, setSignUpData] = useState<SignUpData>({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  });
+
+  const [confirmationCode, setConfirmationCode] = useState('');
+
+  const handleSignIn: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await signIn(signInData.username, signInData.password);
+      toast.success('Successfully signed in!');
+      onClose();
+      setSignInData({ username: '', password: '' });
+    } catch (error: any) {
+      toast.error(error.message || 'Failed to sign in');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSignUp: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+
+    if (signUpData.password !== signUpData.confirmPassword) {
+      toast.error('Passwords do not match');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await signUp(signUpData.username, signUpData.email, signUpData.password);
+      setPendingUsername(signUpData.username);
+      setMode('confirm');
+      toast.success('Account created! Please check your email for confirmation code.');
+      setSignUpData({ username: '', email: '', password: '', confirmPassword: '' });
+    } catch (error: any) {
+      toast.error(error.message || 'Failed to sign up');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirmSignUp: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await confirmSignUp(pendingUsername, confirmationCode);
+      toast.success('Email confirmed! You can now sign in.');
+      setMode('signin');
+      setConfirmationCode('');
+      setPendingUsername('');
+    } catch (error: any) {
+      toast.error(error.message || 'Failed to confirm email');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const goToSignIn = () => setMode('signin');
+  const goToSignUp = () => setMode('signup');
+  const goToConfirm = () => setMode('confirm');
+  const goToForgotPassword = () => setMode('forgot');
+
+  return {
+    mode,
+    loading,
+    signInData,
+    setSignInData,
+    signUpData,
+    setSignUpData,
+    confirmationCode,
+    setConfirmationCode,
+    handleSignIn,
+    handleSignUp,
+    handleConfirmSignUp,
+    goToSignIn,
+    goToSignUp,
+    goToConfirm,
+    goToForgotPassword,
+  };
+};
+

--- a/src/hooks/usePasswordReset.ts
+++ b/src/hooks/usePasswordReset.ts
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { resetPassword, confirmResetPassword } from 'aws-amplify/auth';
+
+type ForgotPasswordStep = 'request' | 'reset';
+
+interface UsePasswordResetOptions {
+  onComplete?: () => void;
+}
+
+interface ForgotPasswordData {
+  username: string;
+  code: string;
+  newPassword: string;
+}
+
+export const usePasswordReset = ({ onComplete }: UsePasswordResetOptions = {}) => {
+  const [forgotPasswordData, setForgotPasswordData] = useState<ForgotPasswordData>({
+    username: '',
+    code: '',
+    newPassword: '',
+  });
+  const [forgotPasswordStep, setForgotPasswordStep] = useState<ForgotPasswordStep>('request');
+  const [loading, setLoading] = useState(false);
+
+  const handleForgotPasswordRequest: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await resetPassword({ username: forgotPasswordData.username });
+      toast.success('Reset code sent to your email');
+      setForgotPasswordStep('reset');
+    } catch (error: any) {
+      toast.error(error.message || 'Failed to send reset code');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePasswordReset: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await confirmResetPassword({
+        username: forgotPasswordData.username,
+        confirmationCode: forgotPasswordData.code,
+        newPassword: forgotPasswordData.newPassword,
+      });
+      toast.success('Password reset successful! You can now sign in.');
+      resetState();
+      onComplete?.();
+    } catch (error: any) {
+      toast.error(error.message || 'Failed to reset password');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resetState = () => {
+    setForgotPasswordData({ username: '', code: '', newPassword: '' });
+    setForgotPasswordStep('request');
+  };
+
+  return {
+    forgotPasswordData,
+    setForgotPasswordData,
+    forgotPasswordStep,
+    loading,
+    handleForgotPasswordRequest,
+    handlePasswordReset,
+    resetState,
+  };
+};
+


### PR DESCRIPTION
Refactor Rationale

Problem — Single Responsibility Violation
`src/components/AuthModal.tsx` was a ~350-line monolithic component that simultaneously handled modal UI chrome, tab navigation, four distinct auth flows (sign-in, sign-up, email confirmation, forgot password), direct Amplify API calls (`resetPassword`, `confirmResetPassword`), form state for all four flows, error handling, and toast notifications. This violated the Single Responsibility Principle — the component had too many reasons to change.

Principle Applied — Separation of Concerns + Abstraction
We decoupled three distinct layers:
- Business logic / workflows → custom hooks
- Service calls → Amplify now fully out of the UI layer
- Rendering → pure presentational components

Before → After Structure

| Before | After |
|---|---|
| `AuthModal.tsx` (~350 lines, mixed concerns) | `AuthModal.tsx` (~80 lines, modal shell only) |
| | `src/hooks/useAuthFlows.ts` |
| | `src/hooks/usePasswordReset.ts` |
| | `src/components/auth/SignInForm.tsx` |
| | `src/components/auth/SignUpForm.tsx` |
| | `src/components/auth/ConfirmEmailForm.tsx` |
| | `src/components/auth/ForgotPasswordForm.tsx` |

---

AI Usage Summary (VIBE Log)

Tool: Cursor Composer (Cmd+I)

Prompt 1 — Diagnostic Audit:
"Audit the entire src/ directory for code smells. Specifically check: (1) any component over 150 lines doing more than one thing, (2) any data fetching or business logic sitting directly inside UI components, (3) any duplicated filtering, sorting, or formatting logic across files, (4) any hardcoded values that should live in a config or constants file. List findings ranked by severity and recommend the single highest-impact refactor I can do right now."

Prompt 2 — Planner:
"Analyze src/components/AuthModal.tsx. Identify all state variables, async handlers, and Amplify calls. Plan a refactor to extract: (1) a useAuthFlows hook that owns the current mode state and sign-in/sign-up handlers, (2) a usePasswordReset hook that owns the forgot-password flow, (3) four presentational components: SignInForm, SignUpForm, ConfirmEmailForm, ForgotPasswordForm. AuthModal should only handle modal chrome and decide which form to render. Do not write code yet — just outline the plan."

Prompt 3 — Coder:
"Now implement the plan. Create src/hooks/useAuthFlows.ts and src/hooks/usePasswordReset.ts. Create src/components/auth/SignInForm.tsx, SignUpForm.tsx, ConfirmEmailForm.tsx, and ForgotPasswordForm.tsx as pure presentational components. Refactor AuthModal.tsx to import and compose these. Remove all Amplify imports and async handlers from AuthModal.tsx. Preserve all existing behavior exactly."

Prompt 4 — Verification:
"Compare the new AuthModal.tsx against the original. Confirm: (1) all four auth flows are still reachable, (2) no Amplify imports remain in AuthModal.tsx, (3) all toast notifications and error handling are preserved, (4) modal open/close behavior is unchanged. List anything dropped or broken."

Human Review & Findings:
Cursor's verification identified two subtle behavior differences which were evaluated and accepted as improvements:
1. "Back to Sign Up" from confirm email — now correctly returns to the Sign Up tab (before it accidentally landed on Sign In due to defaultValue resetting)
2. Forgot-password state on back navigation — now clears the form on "Back to Sign In" (before, a stale username persisted in the session)

No regressions were found. No additional human code fixes were required beyond accepting these UX improvements.

---

Verification — Feature Parity Checklist

| Flow | Result |
|---|---|
| ✅ User can sign in | Works — success toast fires, modal closes |
| ✅ User can sign up | Works — confirmation email flow triggers |
| ✅ Email confirmation code | Works — confirms and returns to sign-in tab |
| ✅ Forgot password (request step) | Works — reset code toast fires, advances to reset step |
| ✅ Forgot password (reset step) | Works — success toast fires, returns to sign-in |
| ✅ Modal closes on successful sign-in | Works — onClose callback wired through useAuthFlows |
| ✅ No Amplify imports in AuthModal.tsx | Confirmed by Cursor verification |
| ✅ All error/toast messages preserved | Confirmed — identical strings, moved into hooks |

Evidence:
<img width="996" height="664" alt="image" src="https://github.com/user-attachments/assets/37a31085-7786-4aff-833f-1cfb6d140286" />
<img width="996" height="664" alt="image" src="https://github.com/user-attachments/assets/b123036f-5083-4233-9e73-0f25dd87279d" />
<img width="1003" height="736" alt="image" src="https://github.com/user-attachments/assets/8598203d-0e2a-4d81-b3ff-0e40ae26a737" />
